### PR TITLE
Add node link to documentation (prerequisite)

### DIFF
--- a/00 Intro/00 BoilerPlate/README.md
+++ b/00 Intro/00 BoilerPlate/README.md
@@ -16,7 +16,7 @@ Summary steps:
 
 ## Prerequisites
 
-Prerequisites, you will need to have nodejs installed in your computer.
+Prerequisites, you will need to have [nodejs](https://nodejs.org/en/) (v. 6.3.1) installed in your computer.
 
 ## steps
 


### PR DESCRIPTION
I have been following the 00 intro step guid and found that installing node link was missing.
